### PR TITLE
Add PathArc::absolute() tests

### DIFF
--- a/tests/absolute_extended_cwd.rs
+++ b/tests/absolute_extended_cwd.rs
@@ -1,0 +1,15 @@
+//! This file tests PathArc::absolute() for Windows when the current directory
+//! uses extended-length path syntax (like `\\?\C:\`).
+extern crate path_abs;
+extern crate tempdir;
+
+// These tests are already run for Unix in absolute_regular_cwd.rs, and Unix
+// doesn't have "extended-length path syntax", so we can make them Windows-only
+// here.
+#[cfg(windows)]
+mod absolute_helpers;
+
+#[cfg(windows)]
+fn setup() {
+    std::env::set_current_dir(r"\\?\C:\").expect("Could not change to a regular directory");
+}

--- a/tests/absolute_helpers/mod.rs
+++ b/tests/absolute_helpers/mod.rs
@@ -1,0 +1,213 @@
+use std::env;
+use std::fs;
+use std::io;
+use std::path;
+
+use path_abs::PathArc;
+
+use tempdir::TempDir;
+
+fn symlink_dir<P, Q>(src: P, dst: Q)
+where
+    P: AsRef<path::Path>,
+    Q: AsRef<path::Path>,
+{
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs as winfs;
+
+        let dst = dst.as_ref();
+
+        winfs::symlink_dir(src, &dst).expect(
+            "Could not create symbolic link. \
+             Run as Administrator, or on Windows 10 in Developer Mode",
+        );
+        dst.symlink_metadata().expect(
+            "Link creation succeeded, but can't read link? \
+             If you're using Wine, see bug 44948",
+        );
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs as unixfs;
+
+        unixfs::symlink(src, dst).expect("Could not create symbolic link");
+    }
+
+    #[cfg(all(not(windows), not(unix)))]
+    unreachable!();
+}
+
+#[test]
+fn absolute_path_is_idempotent() {
+    ::setup();
+    // The current_dir() result is always absolute,
+    // so absolutizing it should not change it.
+
+    let actual = PathArc::new(env::current_dir().unwrap())
+        .absolute()
+        .unwrap();
+    let expected = env::current_dir().unwrap().canonicalize().unwrap();
+
+    assert_eq!(actual.as_path(), expected.as_path());
+}
+
+#[test]
+fn absolute_path_removes_currentdir_component() {
+    ::setup();
+    let actual = PathArc::new("foo/./bar").absolute().unwrap();
+    let expected = PathArc::new("foo/bar").absolute().unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn absolute_path_removes_empty_component() {
+    ::setup();
+    let actual = PathArc::new("foo//bar").absolute().unwrap();
+    let expected = PathArc::new("foo/bar").absolute().unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn absolute_path_lexically_resolves_parentdir_component() {
+    ::setup();
+    let tmp_dir = TempDir::new("normalize_parentdir").unwrap();
+    let a_dir = tmp_dir.path().join("a");
+    fs::create_dir_all(&a_dir).unwrap();
+
+    let b_dir = tmp_dir.path().join("b");
+    fs::create_dir_all(&b_dir).unwrap();
+
+    fs::create_dir_all(&b_dir.join("target")).unwrap();
+
+    let link_path = a_dir.join("link");
+    symlink_dir("../b/target", link_path);
+
+    // Because of the symlink, a/link/../foo is actually b/foo, but
+    // lexically resolving the path produces a/foo.
+    let actual = PathArc::new(a_dir.join("link/../foo")).absolute().unwrap();
+    let expected = PathArc::new(a_dir.join("foo")).absolute().unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn absolute_path_interprets_relative_to_current_directory() {
+    ::setup();
+    let actual = PathArc::new("foo").absolute().unwrap();
+    let expected = PathArc::new(env::current_dir().unwrap())
+        .join("foo")
+        .absolute()
+        .unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[cfg(unix)]
+mod unix {
+    use super::*;
+
+    #[test]
+    fn absolute_path_need_not_exist() {
+        ::setup();
+
+        // It's not likely this path would exist, but let's be sure.
+        let raw_path = path::Path::new("/does/not/exist");
+        assert_eq!(
+            raw_path.metadata().unwrap_err().kind(),
+            io::ErrorKind::NotFound,
+        );
+
+        let path = PathArc::new(raw_path).absolute().unwrap();
+
+        assert_eq!(path.as_os_str(), "/does/not/exist");
+    }
+
+    #[test]
+    fn absolute_path_cannot_go_above_root() {
+        ::setup();
+        let err = PathArc::new("/foo/../..").absolute().unwrap_err();
+
+        assert_eq!(err.io_error().kind(), io::ErrorKind::NotFound);
+        assert_eq!(
+            err.io_error().to_string(),
+            "resolving resulted in empty path"
+        );
+        assert_eq!(err.action(), "resolving absolute");
+        assert_eq!(err.path(), path::Path::new("/foo/../.."));
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::*;
+
+    #[test]
+    fn absolute_path_need_not_exist() {
+        ::setup();
+
+        // It's not likely this path would exist, but let's be sure.
+        let raw_path = path::Path::new(r"C:\does\not\exist");
+        assert_eq!(
+            raw_path.metadata().unwrap_err().kind(),
+            io::ErrorKind::NotFound,
+        );
+
+        let path = PathArc::new(raw_path).absolute().unwrap();
+        assert_eq!(path.as_os_str(), r"\\?\C:\does\not\exist");
+    }
+
+    #[test]
+    fn absolute_path_cannot_go_above_root() {
+        ::setup();
+        // TODO: This is broken, and only really works if the current
+        // directory on C: is \. Otherwise, handle_prefix() canonicalizes
+        // "C:" to get "C:\Users\st" then appends "\", "foo", "..", ".."
+        // and gets back to "C:\Users\st".
+        let actual = PathArc::new(r"C:\foo\..\..").absolute().unwrap();
+        let expected = PathArc::new(path::Path::new(r"C:").canonicalize().unwrap())
+            .absolute()
+            .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn absolute_supports_root_only_relative_path() {
+        ::setup();
+        let actual = PathArc::new(r"\foo").absolute().unwrap();
+
+        let mut current_drive_root = path::PathBuf::new();
+        current_drive_root.extend(
+            env::current_dir().unwrap().components().take(2), // the prefix (C:) and root (\) components
+        );
+
+        let expected = PathArc::new(current_drive_root.join("foo"))
+            .absolute()
+            .unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn absolute_supports_prefix_only_relative_path() {
+        ::setup();
+        let actual = PathArc::new(r"C:foo").absolute().unwrap();
+
+        let expected = PathArc::new(path::Path::new(r"C:").canonicalize().unwrap().join("foo"))
+            .absolute()
+            .unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn absolute_accepts_bogus_prefix() {
+        ::setup();
+        let path = PathArc::new(r"\\?\bogus\path\").absolute().unwrap();
+
+        assert_eq!(path.as_os_str(), r"\\?\bogus\path");
+    }
+}

--- a/tests/absolute_regular_cwd.rs
+++ b/tests/absolute_regular_cwd.rs
@@ -1,0 +1,12 @@
+extern crate path_abs;
+extern crate tempdir;
+
+mod absolute_helpers;
+
+fn setup() {
+    #[cfg(windows)]
+    std::env::set_current_dir(r"C:\").expect("Could not change to a regular directory");
+
+    // For cfg(unix), we're always in a regular directory, so we don't need to
+    // do anything special.
+}

--- a/tests/test_windows.rs
+++ b/tests/test_windows.rs
@@ -84,14 +84,6 @@ fn hostname() -> String {
 //     out
 // }
 
-#[cfg_attr(windows, test)]
-fn canonicalize_root() {
-    // TODO:
-    // This works here, but it doesn't work when called in src/arc.rs::handle_prefix
-    // during `test_absolute`, possibly related to setting the current_dir?
-    expect_path!(r"\\?\C:\", r"\");
-}
-
 // TODO: I don't know what is even a valid verbatum path, and I can't list it directly
 // ERROR: "The filename, directory name, or volume label syntax is incorrect."
 //
@@ -120,6 +112,8 @@ fn canonicalize_verbatim_unc() {
     // Remote IPC     IPC$
     // ###
 
+    // TODO: Only works on Windows hosts with the default administrative
+    // file shares enabled.
     let _ = share(); // FIXME: just printing for now
     let p = format!(r"\\?\UNC\{}\C$", hostname());
     expect_path!(&p, &p);
@@ -145,6 +139,8 @@ fn canonicalize_verbatim_disk() {
 
 #[cfg_attr(windows, test)]
 fn canonicalize_unc() {
+    // TODO: Only works on Windows hosts with the default administrative
+    // file shares enabled.
     let h = hostname();
     let unc = format!(r"\\{}\C$", h);
     let verbatim = format!(r"\\?\UNC\{}\C$", h);


### PR DESCRIPTION
This PR adds a bunch of tests for PathArc::absolute(), in various situations: on POSIX, on Windows when the current directory is a regular path (`C:\`), and on Windows when the current directory is an extended-length syntax path (`\\?\C:\`).

I made this as a separate PR for a few reasons:

- to get feedback on the somewhat unusual way I've laid out the tests
- so that a future PR for issue #21 can highlight behaviour changes by changing these tests
- to find out whether these tests will pass on AppVeyor the same way they passed in my VM. :)

This PR also adds some "TODO" comments to tests that I've observed to fail in various environments, just for completeness.