### PR TITLE
Remove the `arc::handle_prefix()` helper.

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -214,7 +214,7 @@ impl PathArc {
         let mut res = PathBuf::new();
 
         fn maybe_init_res(res: &mut PathBuf, resolvee: &PathArc) -> Result<()> {
-            if res.as_os_str() != "" {
+            if !res.as_os_str().is_empty() {
                 // res has already been initialized, let's leave it alone.
                 return Ok(());
             }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -245,8 +245,17 @@ impl PathArc {
 
                 Component::RootDir => {
                     if cfg!(windows) {
-                        // A root path component is relative to some existing
-                        // path, so we may need to initialize res.
+                        // In an ideal world, we would say
+                        //
+                        //  res = std::fs::canonicalize(each)?;
+                        //
+                        // ...to get a properly canonicalized path.
+                        // Unfortunately, Windows cannot canonicalize `\` if
+                        // the current directory happens to use extended-length
+                        // syntax (like `\\?\C:\Windows`), so we'll have to do
+                        // it manually: initialize `res` with the current
+                        // working directory (whatever it is), and truncate it
+                        // to its prefix by pushing `\`.
                         maybe_init_res(&mut res, self)?;
                         res.push(each);
                     } else {

--- a/tests/absolute_helpers/mod.rs
+++ b/tests/absolute_helpers/mod.rs
@@ -134,7 +134,7 @@ mod unix {
         assert_eq!(err.io_error().kind(), io::ErrorKind::NotFound);
         assert_eq!(
             err.io_error().to_string(),
-            "resolving resulted in empty path"
+            ".. consumed root"
         );
         assert_eq!(err.action(), "resolving absolute");
         assert_eq!(err.path(), path::Path::new("/foo/../.."));
@@ -163,15 +163,15 @@ mod windows {
     #[test]
     fn absolute_path_cannot_go_above_root() {
         ::setup();
-        // TODO: This is broken, and only really works if the current
-        // directory on C: is \. Otherwise, handle_prefix() canonicalizes
-        // "C:" to get "C:\Users\st" then appends "\", "foo", "..", ".."
-        // and gets back to "C:\Users\st".
-        let actual = PathArc::new(r"C:\foo\..\..").absolute().unwrap();
-        let expected = PathArc::new(path::Path::new(r"C:").canonicalize().unwrap())
-            .absolute()
-            .unwrap();
-        assert_eq!(actual, expected);
+        let err = PathArc::new(r"C:\foo\..\..").absolute().unwrap_err();
+
+        assert_eq!(err.io_error().kind(), io::ErrorKind::NotFound);
+        assert_eq!(
+            err.io_error().to_string(),
+            ".. consumed root"
+        );
+        assert_eq!(err.action(), "resolving absolute");
+        assert_eq!(err.path(), path::Path::new(r"C:\foo\..\.."));
     }
 
     #[test]


### PR DESCRIPTION
This makes `PathArc::absolute()` simpler, and makes the `absolute_path_cannot_go_above_root` test consistent between Windows and other platforms.

Fixes #21.