### PR TITLE
Clean up trait implementations.

### DIFF
--- a/src/abs.rs
+++ b/src/abs.rs
@@ -279,8 +279,22 @@ impl Deref for PathAbs {
     }
 }
 
-impl Into<PathArc> for PathAbs {
-    fn into(self) -> PathArc {
-        self.0
+impl From<PathAbs> for PathArc {
+    fn from(path: PathAbs) -> PathArc {
+        path.0
+    }
+}
+
+impl From<PathAbs> for Arc<PathBuf> {
+    fn from(path: PathAbs) -> Arc<PathBuf> {
+        let arc: PathArc = path.into();
+        arc.0
+    }
+}
+
+impl From<PathAbs> for PathBuf {
+    fn from(path: PathAbs) -> PathBuf {
+        let arc: PathArc = path.into();
+        arc.into()
     }
 }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -221,33 +221,27 @@ impl Deref for PathArc {
     }
 }
 
-impl From<PathBuf> for PathArc {
-    /// Instantiate a new `PathArc` from a `PathBuf`.
-    fn from(path: PathBuf) -> PathArc {
-        PathArc(Arc::new(path))
+impl From<Arc<PathBuf>> for PathArc {
+    fn from(path: Arc<PathBuf>) -> PathArc {
+        PathArc(path)
     }
 }
 
-impl Into<PathBuf> for PathArc {
-    /// If there is only one reference to the `PathArc`, returns
-    /// the inner `PathBuf`. Otherwise clones the inner `PathBuf`.
-    ///
-    /// This is useful when you really want a `PathBuf`, especially
-    /// when the `PathArc` was only recently created.
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate path_abs;
-    /// use path_abs::PathArc;
-    /// use std::path::PathBuf;
-    ///
-    /// # fn try_main() -> ::std::io::Result<()> {
-    /// let base = PathArc::new("base");
-    /// let foo: PathBuf = base.join("foo.txt").into();
-    /// # Ok(()) } fn main() { try_main().unwrap() }
-    /// ```
-    fn into(self) -> PathBuf {
-        match Arc::try_unwrap(self.0) {
+impl From<PathBuf> for PathArc {
+    fn from(path: PathBuf) -> PathArc {
+        Arc::new(path).into()
+    }
+}
+
+impl From<PathArc> for Arc<PathBuf> {
+    fn from(path: PathArc) -> Arc<PathBuf> {
+        path.0
+    }
+}
+
+impl From<PathArc> for PathBuf {
+    fn from(path: PathArc) -> PathBuf {
+        match Arc::try_unwrap(path.0) {
             Ok(p) => p,
             Err(inner) => inner.as_ref().clone(),
         }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -460,49 +460,30 @@ impl Deref for PathDir {
     }
 }
 
-impl Into<PathAbs> for PathDir {
-    /// Downgrades the `PathDir` into a `PathAbs`
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate path_abs;
-    /// use std::path::PathBuf;
-    /// use path_abs::{PathDir, PathAbs};
-    ///
-    /// # fn try_main() -> ::std::io::Result<()> {
-    /// let dir = PathDir::new("src")?;
-    /// let abs: PathAbs = dir.into();
-    /// # Ok(()) } fn main() { try_main().unwrap() }
-    /// ```
-    fn into(self) -> PathAbs {
-        self.0
+impl From<PathDir> for PathAbs {
+    fn from(path: PathDir) -> PathAbs {
+        path.0
     }
 }
 
-impl Into<PathArc> for PathDir {
-    /// Downgrades the `PathDir` into a `PathArc`
-    fn into(self) -> PathArc {
-        (self.0).0
+impl From<PathDir> for PathArc {
+    fn from(path: PathDir) -> PathArc {
+        let abs: PathAbs = path.into();
+        abs.0
     }
 }
 
-impl Into<PathBuf> for PathDir {
-    /// Downgrades the `PathDir` into a `PathBuf`. Avoids a clone if this is the only reference.
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate path_abs;
-    /// use path_abs::PathDir;
-    /// use std::path::PathBuf;
-    ///
-    /// # fn try_main() -> ::std::io::Result<()> {
-    /// let dir = PathDir::new("src")?;
-    /// let buf: PathBuf = dir.into();
-    /// # Ok(()) } fn main() { try_main().unwrap() }
-    /// ```
-    fn into(self) -> PathBuf {
-        let arc: PathArc = self.into();
-        arc.into()
+impl From<PathDir> for Arc<PathBuf> {
+    fn from(path: PathDir) -> Arc<PathBuf> {
+        let abs: PathAbs = path.into();
+        abs.into()
+    }
+}
+
+impl From<PathDir> for PathBuf {
+    fn from(path: PathDir) -> PathBuf {
+        let abs: PathAbs = path.into();
+        abs.into()
     }
 }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -222,6 +222,42 @@ impl io::Seek for FileEdit {
     }
 }
 
+impl AsRef<FileOpen> for FileEdit {
+    fn as_ref(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl AsRef<File> for FileEdit {
+    fn as_ref(&self) -> &File {
+        &self.0.as_ref()
+    }
+}
+
+impl Borrow<FileOpen> for FileEdit {
+    fn borrow(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl Borrow<File> for FileEdit {
+    fn borrow(&self) -> &File {
+        &self.0.borrow()
+    }
+}
+
+impl<'a> Borrow<FileOpen> for &'a FileEdit {
+    fn borrow(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl<'a> Borrow<File> for &'a FileEdit {
+    fn borrow(&self) -> &File {
+        &self.0.borrow()
+    }
+}
+
 impl Deref for FileEdit {
     type Target = FileOpen;
 
@@ -230,8 +266,14 @@ impl Deref for FileEdit {
     }
 }
 
-impl Into<File> for FileEdit {
-    fn into(self) -> File {
-        self.0.into()
+impl From<FileEdit> for FileOpen {
+    fn from(orig: FileEdit) -> FileOpen {
+        orig.0
+    }
+}
+
+impl From<FileEdit> for File {
+    fn from(orig: FileEdit) -> File {
+        orig.0.into()
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -550,49 +550,30 @@ impl Deref for PathFile {
     }
 }
 
-impl Into<PathAbs> for PathFile {
-    /// Downgrades the `PathFile` into a `PathAbs`
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate path_abs;
-    /// use std::path::PathBuf;
-    /// use path_abs::{PathFile, PathAbs};
-    ///
-    /// # fn try_main() -> ::std::io::Result<()> {
-    /// let file = PathFile::new("src/lib.rs")?;
-    /// let abs: PathAbs = file.clone().into();
-    /// # Ok(()) } fn main() { try_main().unwrap() }
-    /// ```
-    fn into(self) -> PathAbs {
-        self.0
+impl From<PathFile> for PathAbs {
+    fn from(path: PathFile) -> PathAbs {
+        path.0
     }
 }
 
-impl Into<PathArc> for PathFile {
-    /// Downgrades the `PathFile` into a `PathArc`
-    fn into(self) -> PathArc {
-        (self.0).0
+impl From<PathFile> for PathArc {
+    fn from(path: PathFile) -> PathArc {
+        let abs: PathAbs = path.into();
+        abs.into()
     }
 }
 
-impl Into<PathBuf> for PathFile {
-    /// Downgrades the `PathFile` into a `PathBuf`. Avoids a clone if this is the only reference.
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate path_abs;
-    /// use path_abs::PathFile;
-    /// use std::path::PathBuf;
-    ///
-    /// # fn try_main() -> ::std::io::Result<()> {
-    /// let file = PathFile::new("src/lib.rs")?;
-    /// let buf: PathBuf = file.into();
-    /// # Ok(()) } fn main() { try_main().unwrap() }
-    /// ```
-    fn into(self) -> PathBuf {
-        let arc: PathArc = self.into();
-        arc.into()
+impl From<PathFile> for Arc<PathBuf> {
+    fn from(path: PathFile) -> Arc<PathBuf> {
+        let abs: PathAbs = path.into();
+        abs.into()
+    }
+}
+
+impl From<PathFile> for PathBuf {
+    fn from(path: PathFile) -> PathBuf {
+        let abs: PathAbs = path.into();
+        abs.into()
     }
 }
 

--- a/src/open.rs
+++ b/src/open.rs
@@ -93,8 +93,26 @@ impl fmt::Debug for FileOpen {
     }
 }
 
-impl Into<fs::File> for FileOpen {
-    fn into(self) -> fs::File {
-        self.file
+impl AsRef<fs::File> for FileOpen {
+    fn as_ref(&self) -> &fs::File {
+        &self.file
+    }
+}
+
+impl Borrow<fs::File> for FileOpen {
+    fn borrow(&self) -> &fs::File {
+        &self.file
+    }
+}
+
+impl<'a> Borrow<fs::File> for &'a FileOpen {
+    fn borrow(&self) -> &fs::File {
+        &self.file
+    }
+}
+
+impl From<FileOpen> for fs::File {
+    fn from(orig: FileOpen) -> fs::File {
+        orig.file
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -99,6 +99,42 @@ impl io::Seek for FileRead {
     }
 }
 
+impl AsRef<FileOpen> for FileRead {
+    fn as_ref(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl AsRef<File> for FileRead {
+    fn as_ref(&self) -> &File {
+        self.0.as_ref()
+    }
+}
+
+impl Borrow<FileOpen> for FileRead {
+    fn borrow(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl Borrow<File> for FileRead {
+    fn borrow(&self) -> &File{
+        self.0.borrow()
+    }
+}
+
+impl<'a> Borrow<FileOpen> for &'a FileRead {
+    fn borrow(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl<'a> Borrow<File> for &'a FileRead {
+    fn borrow(&self) -> &File{
+        self.0.borrow()
+    }
+}
+
 impl Deref for FileRead {
     type Target = FileOpen;
 
@@ -107,8 +143,14 @@ impl Deref for FileRead {
     }
 }
 
-impl Into<File> for FileRead {
-    fn into(self) -> File {
-        self.0.into()
+impl From<FileRead> for FileOpen {
+    fn from(orig: FileRead) -> FileOpen {
+        orig.0
+    }
+}
+
+impl From<FileRead> for File {
+    fn from(orig: FileRead) -> File {
+        orig.0.into()
     }
 }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -215,52 +215,32 @@ impl<'a> Borrow<PathBuf> for &'a PathType {
     }
 }
 
-impl Into<PathAbs> for PathType {
-    /// Downgrades the `PathType` into a `PathAbs`
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate path_abs;
-    /// use std::path::PathBuf;
-    /// use path_abs::{PathType, PathAbs};
-    ///
-    /// # fn try_main() -> ::std::io::Result<()> {
-    /// let ty = PathType::new("src/lib.rs")?;
-    /// let abs: PathAbs = ty.into();
-    /// # Ok(()) } fn main() { try_main().unwrap() }
-    /// ```
-    fn into(self) -> PathAbs {
-        match self {
+impl From<PathType> for PathAbs {
+    fn from(path: PathType) -> PathAbs {
+        match path {
             PathType::File(p) => p.into(),
             PathType::Dir(p) => p.into(),
         }
     }
 }
 
-impl Into<PathArc> for PathType {
-    /// Downgrades the `PathType` into a `PathArc`
-    fn into(self) -> PathArc {
-        let abs: PathAbs = self.into();
+impl From<PathType> for PathArc {
+    fn from(path: PathType) -> PathArc {
+        let abs: PathAbs = path.into();
         abs.into()
     }
 }
 
-impl Into<PathBuf> for PathType {
-    /// Downgrades the `PathType` into a `PathBuf`. Avoids a clone if this is the only reference.
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate path_abs;
-    /// use path_abs::PathType;
-    /// use std::path::PathBuf;
-    ///
-    /// # fn try_main() -> ::std::io::Result<()> {
-    /// let ty = PathType::new("src/lib.rs")?;
-    /// let buf: PathBuf = ty.into();
-    /// # Ok(()) } fn main() { try_main().unwrap() }
-    /// ```
-    fn into(self) -> PathBuf {
-        let arc: PathArc = self.into();
-        arc.into()
+impl From<PathType> for Arc<PathBuf> {
+    fn from(path: PathType) -> Arc<PathBuf> {
+        let abs: PathAbs = path.into();
+        abs.into()
+    }
+}
+
+impl From<PathType> for PathBuf {
+    fn from(path: PathType) -> PathBuf {
+        let abs: PathAbs = path.into();
+        abs.into()
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -196,6 +196,42 @@ impl io::Seek for FileWrite {
     }
 }
 
+impl AsRef<FileOpen> for FileWrite {
+    fn as_ref(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl AsRef<File> for FileWrite {
+    fn as_ref(&self) -> &File {
+        self.0.as_ref()
+    }
+}
+
+impl Borrow<FileOpen> for FileWrite {
+    fn borrow(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl Borrow<File> for FileWrite {
+    fn borrow(&self) -> &File{
+        self.0.borrow()
+    }
+}
+
+impl<'a> Borrow<FileOpen> for &'a FileWrite {
+    fn borrow(&self) -> &FileOpen {
+        &self.0
+    }
+}
+
+impl<'a> Borrow<File> for &'a FileWrite {
+    fn borrow(&self) -> &File{
+        self.0.borrow()
+    }
+}
+
 impl Deref for FileWrite {
     type Target = FileOpen;
 
@@ -204,8 +240,14 @@ impl Deref for FileWrite {
     }
 }
 
-impl Into<File> for FileWrite {
-    fn into(self) -> File {
-        self.0.into()
+impl From<FileWrite> for FileOpen {
+    fn from(orig: FileWrite) -> FileOpen {
+        orig.0
+    }
+}
+
+impl From<FileWrite> for File {
+    fn from(orig: FileWrite) -> File {
+        orig.0.into()
     }
 }


### PR DESCRIPTION
Now every struct has the complete set of AsRef, Borrow and From impls to get at the things inside it. There are also From impls for constructing structs where that is infallible.

Into impls have been removed, since the standard library has a blanket impl for everything that implements From.