### PR TITLE
Fix joining relative path in windows

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -65,7 +65,12 @@ impl PathArc {
     ///
     /// [0]: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join
     pub fn join<P: AsRef<Path>>(&self, path: P) -> PathArc {
-        PathArc::from(self.0.join(path))
+        let mut joined_path = self.as_path().to_path_buf();
+        // Issue #34: Convert '/' into '\\' for Windows
+        for c in path.as_ref().components() {
+            joined_path.push(c);
+        }
+        PathArc::from(joined_path)
     }
 
     /// Creates an owned `PathArc` like self but with the given file name.


### PR DESCRIPTION
Fix #34

When joining path, the components of the path to join are pushed one by one
instead of using directly `PathBuf::join()`. Since `PathAbs` canonicalize the
path when calling `PahtAbs::new()`, the path is converted to extended length
path syntax on Windows. This syntax doesn't allow using '/'-separated path, but
Windows allows '/'-separated path otherwise. Joining the path component by
component permits `PathBuf` to do the right thing when joining a '/'-separated
relative path to a `PathAbs`.