### PR TITLE
change concat behavior, rename truncate_to_parent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1161,6 +1161,42 @@ mod tests {
         }
 
         #[test]
+        fn test_pathops_concat_relative() {
+            let actual = Path::new("../foo")
+                .to_path_buf()
+                .concat("bar")
+                .expect("Could not create relative path with concat");
+            let expected = Path::new(r"../foo/bar").to_path_buf();
+            assert_eq!(actual, expected);
+
+            let actual = Path::new("../foo")
+                .to_path_buf()
+                .concat("..")
+                .expect("Could not create relative path with concat");
+            let expected = Path::new(r"..").to_path_buf();
+            assert_eq!(actual, expected);
+
+            // FIXME: fails with result being ""
+            let actual = Path::new("../foo")
+                .to_path_buf()
+                .concat("../..")
+                .expect("Could not create relative path with concat");
+            let expected = Path::new(r"../..").to_path_buf();
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_pathops_concat_consume() {
+            // FIXME: fails that you aren't allowed to consume the parent
+            let actual = Path::new("foo")
+                .to_path_buf()
+                .concat("../../bar")
+                .expect("Could not create relative path with concat");
+            let expected = Path::new(r"../bar").to_path_buf();
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
         fn test_pathmut_append() {
             let mut actual = Path::new("foo").to_path_buf();
             actual

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -99,7 +99,7 @@ impl<'de> Deserialize<'de> for PathFile {
         D: Deserializer<'de>,
     {
         let abs = PathAbs::deserialize(deserializer)?;
-        PathFile::from_abs(abs).map_err(|err| serde::de::Error::custom(&err.to_string()))
+        PathFile::try_from(abs).map_err(|err| serde::de::Error::custom(&err.to_string()))
     }
 }
 
@@ -109,7 +109,7 @@ impl<'de> Deserialize<'de> for PathDir {
         D: Deserializer<'de>,
     {
         let abs = PathAbs::deserialize(deserializer)?;
-        PathDir::from_abs(abs).map_err(|err| serde::de::Error::custom(&err.to_string()))
+        PathDir::try_from(abs).map_err(|err| serde::de::Error::custom(&err.to_string()))
     }
 }
 

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -45,11 +45,12 @@ impl PathType {
     /// # Ok(()) } fn main() { try_main().unwrap() }
     pub fn new<P: AsRef<Path>>(path: P) -> Result<PathType> {
         let abs = PathAbs::new(&path)?;
-        PathType::from_abs(abs)
+        PathType::try_from(abs)
     }
 
     /// Consume the `PathAbs` returning the `PathType`.
-    pub fn from_abs(abs: PathAbs) -> Result<PathType> {
+    pub fn try_from<P: Into<PathAbs>>(path: P) -> Result<PathType> {
+        let abs = path.into();
         let ty = abs.metadata()?.file_type();
         if ty.is_file() {
             Ok(PathType::File(PathFile(abs)))
@@ -116,19 +117,11 @@ impl PathType {
             false
         }
     }
+}
 
-    /// Create a mock file type. *For use in tests only*.
-    ///
-    /// See the docs for [`PathAbs::mock`](struct.PathAbs.html#method.mock)
-    pub fn mock_file<P: AsRef<Path>>(path: P) -> PathType {
-        PathType::File(PathFile::mock(path))
-    }
-
-    /// Create a mock dir type. *For use in tests only*.
-    ///
-    /// See the docs for [`PathAbs::mock`](struct.PathAbs.html#method.mock)
-    pub fn mock_dir<P: AsRef<Path>>(path: P) -> PathType {
-        PathType::Dir(PathDir::mock(path))
+impl AsRef<ffi::OsStr> for PathType {
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        self.0.as_ref().as_ref()
     }
 }
 


### PR DESCRIPTION
This adds some failing tests that I think `concat` should be able to handle.