### PR TITLE
add PathSer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,8 @@ pub use crate::abs::PathAbs;
 pub use crate::dir::{ListDir, PathDir};
 pub use crate::file::PathFile;
 pub use crate::ty::PathType;
+#[cfg(feature = "serialize")]
+pub use crate::ser::PathSer;
 
 pub use crate::edit::FileEdit;
 pub use crate::read::FileRead;


### PR DESCRIPTION
One of the primary reasons I created this crate was to be able to serialize arbitrary paths. Now that `PathArc` is removed, that isn't possible!

This adds the `PathSer` type. It looks and behaves like `PathBuf`, but is serializable.