### PR TITLE
Fix WASI symlink implementation

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -525,8 +525,7 @@ impl PathOps for PathDir {
 
 #[cfg(target_os = "wasi")]
 fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
-    let file = std::fs::File::open(&src)?;
-    std::os::wasi::fs::symlink(src, &file, dst)
+    std::os::wasi::fs::symlink_path(src, dst)
 }
 
 #[cfg(unix)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -572,8 +572,7 @@ impl PathOps for PathFile {
 
 #[cfg(target_os = "wasi")]
 fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
-    let file = std::fs::File::open(&src)?;
-    std::os::wasi::fs::symlink(src, &file, dst)
+    std::os::wasi::fs::symlink_path(src, dst)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
As described in #51, current implementation is incorrect and won't work and, as described in https://github.com/rust-lang/rust/issues/68574, there was no correct way to use that API.

I went ahead and added a new API for symlinks in https://github.com/rust-lang/rust/pull/81542, and now that it's landed, it can be used to correctly create symlinks.

Fixes #51.